### PR TITLE
Django 2.0

### DIFF
--- a/src/swingtime/admin.py
+++ b/src/swingtime/admin.py
@@ -1,4 +1,4 @@
-from django.contrib.contenttypes import generic
+from django.contrib.contenttypes.admin import GenericTabularInline
 from django.contrib import admin
 from swingtime.models import *
 
@@ -16,7 +16,7 @@ class OccurrenceInline(admin.TabularInline):
     extra = 1
 
 
-class EventNoteInline(generic.GenericTabularInline):
+class EventNoteInline(GenericTabularInline):
     model = Note
     extra = 1
 

--- a/src/swingtime/conf/__init__.py
+++ b/src/swingtime/conf/__init__.py
@@ -1,5 +1,5 @@
 from django.conf import settings
-import swingtime_settings
+from . import swingtime_settings
 
 
 class AppSettings(object):
@@ -16,7 +16,7 @@ class AppSettings(object):
             self.SETTINGS_MODULE = getattr(settings, global_override)
             try:
                 mod = __import__(self.SETTINGS_MODULE, {}, {}, [''])
-            except ImportError, e:
+            except ImportError as e:
                 raise ImportError(
                     "Could not import settings '%s' (Is it on sys.path? Does it have syntax errors?): %s" % (self.SETTINGS_MODULE, e)
                 )

--- a/src/swingtime/forms.py
+++ b/src/swingtime/forms.py
@@ -5,7 +5,7 @@ from datetime import datetime, date, time, timedelta
 
 from django import forms
 from django.utils.translation import ugettext_lazy as _
-from django.forms.extras.widgets import SelectDateWidget
+from django.forms import SelectDateWidget
 
 from dateutil import rrule
 from swingtime.conf import settings as swingtime_settings
@@ -375,6 +375,7 @@ class EventForm(forms.ModelForm):
 
     class Meta:
         model = Event
+        fields = '__all__'
 
     def __init__(self, *args, **kws):
         super(EventForm, self).__init__(*args, **kws)
@@ -391,3 +392,4 @@ class SingleOccurrenceForm(forms.ModelForm):
 
     class Meta:
         model = Occurrence
+        fields = '__all__'

--- a/src/swingtime/models.py
+++ b/src/swingtime/models.py
@@ -2,7 +2,7 @@ from datetime import datetime, date, timedelta
 
 from django.utils.translation import ugettext_lazy as _
 from django.contrib.contenttypes.models import ContentType
-from django.contrib.contenttypes import generic
+from django.contrib.contenttypes.fields import GenericForeignKey, GenericRelation
 from django.db import models
 from django.contrib.auth.models import User
 from django.conf import settings
@@ -26,9 +26,9 @@ class Note(models.Model):
     note = models.TextField(_('note'))
     created = models.DateTimeField(_('created'), auto_now_add=True)
 
-    content_type = models.ForeignKey(ContentType, verbose_name=_('content type'))
+    content_type = models.ForeignKey(ContentType, on_delete=models.CASCADE, verbose_name=_('content type'))
     object_id = models.PositiveIntegerField(_('object id'))
-    content_object = generic.GenericForeignKey('content_type', 'object_id')
+    content_object = GenericForeignKey('content_type', 'object_id')
 
     class Meta:
         verbose_name = _('note')
@@ -59,8 +59,8 @@ class Event(models.Model):
     """
     title = models.CharField(_('title'), max_length=32)
     description = models.CharField(_('description'), max_length=100)
-    event_type = models.ForeignKey(EventType, verbose_name=_('event type'))
-    notes = generic.GenericRelation(Note, verbose_name=_('notes'))
+    event_type = models.ForeignKey(EventType, on_delete=models.CASCADE, verbose_name=_('event type'))
+    notes = GenericRelation(Note, verbose_name=_('notes'))
 
     class Meta:
         verbose_name = _('event')
@@ -70,7 +70,6 @@ class Event(models.Model):
     def __unicode__(self):
         return self.title
 
-    @models.permalink
     def get_absolute_url(self):
         return ('swingtime-event', [str(self.id)])
 
@@ -164,8 +163,8 @@ class Occurrence(models.Model):
     """
     start_time = models.DateTimeField(_('start time'))
     end_time = models.DateTimeField(_('end time'))
-    event = models.ForeignKey(Event, verbose_name=_('event'), editable=False)
-    notes = generic.GenericRelation(Note, verbose_name=_('notes'))
+    event = models.ForeignKey(Event, on_delete=models.CASCADE, verbose_name=_('event'), editable=False)
+    notes = GenericRelation(Note, verbose_name=_('notes'))
 
     objects = OccurrenceManager()
 
@@ -177,7 +176,6 @@ class Occurrence(models.Model):
     def __unicode__(self):
         return u'%s: %s' % (self.title, self.start_time.isoformat())
 
-    @models.permalink
     def get_absolute_url(self):
         return ('swingtime-occurrence', [str(self.event.id), str(self.id)])
 

--- a/src/swingtime/utils.py
+++ b/src/swingtime/utils.py
@@ -87,7 +87,7 @@ class DefaultOccurrenceProxy(BaseOccurrenceProxy):
 
     @html_mark_safe
     def __unicode__(self):
-        print self.title
+        print (self.title)
         return self._str()
 
 


### PR DESCRIPTION
Remove references to models.permalink apis which are now removed in django 2 and update codes causing app loading issues.